### PR TITLE
Ignores all WebStorm config file changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ npm-debug.log
 
 # Ignore bower libraries
 public/lib
+
+# Ignore WebStorm config files
+.idea


### PR DESCRIPTION
When the repo is cloned and opened in WebStorm, certain .idea files are created for the repo. These should be ignored and this PR does just that.
